### PR TITLE
oci_discovery/ref_engine_discovery: Catch HTTPError for ref_engine.resolve

### DIFF
--- a/oci_discovery/ref_engine_discovery/__init__.py
+++ b/oci_discovery/ref_engine_discovery/__init__.py
@@ -59,7 +59,7 @@ def resolve(name, protocols=('https', 'http')):
                     continue
                 try:
                     roots = list(ref_engine.resolve(name=name))
-                except _urllib_error.URLError as error:
+                except _urllib_error.HTTPError as error:
                     _LOGGER.warning('failed to fetch {} ({})'.format(
                         error.geturl(), error))
                     continue


### PR DESCRIPTION
Instead of catching `URLError`.  `URLError` is [for protocol-level issues][1] (e.g. wrapping an `SSLError` if you attempt an HTTPS connection to a server that does not speak TLS).  They do not have much structure.

`HTTPError`, on the other hand, is [for things like 400 errors][2] and they do support things like [`geturl`][3].

[1]: https://docs.python.org/3/library/urllib.error.html#urllib.error.URLError
[2]: https://docs.python.org/3/library/urllib.error.html#urllib.error.HTTPError
[3]: https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen