### PR TITLE
README: Replace 'python' with 'python3'

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The strategies in these specifications are inspired by some previous implementat
 The individual components are usable as libraries, but the ref-engine discovery implementation can also be used from the command line:
 
 ```
-$ python -m oci_discovery.ref_engine_discovery -l debug example.com/app#1.0 2>/tmp/log
+$ python3 -m oci_discovery.ref_engine_discovery -l debug example.com/app#1.0 2>/tmp/log
 {
   "example.com/app#1.0": {
     "roots": [


### PR DESCRIPTION
I expect the code I wrote only works on Python 3, and [PEP 394][1] suggests `python3` for that.  I got the `Makefile` entries right in 89e3eb5 (#2), but botched this one.

[1]: https://www.python.org/dev/peps/pep-0394/#recommendation