### PR TITLE
oci_discovery/ref_engine_discovery/ancestor_hosts.py: Handle dotless names

### DIFF
--- a/oci_discovery/ref_engine_discovery/ancestor_hosts.py
+++ b/oci_discovery/ref_engine_discovery/ancestor_hosts.py
@@ -34,5 +34,8 @@ def ancestor_hosts(host):
         yield host
         return  # no ancestor domains for IPv4 addresses
     segments = host.split('.')
+    if '.' not in host:
+        yield host
+        return
     for i in range(len(segments) - 1):
         yield '.'.join(segments[i:])

--- a/oci_discovery/ref_engine_discovery/test_ancestor_hosts.py
+++ b/oci_discovery/ref_engine_discovery/test_ancestor_hosts.py
@@ -45,6 +45,7 @@ class TestIPv4Detection(unittest.TestCase):
 class TestAncestorHosts(unittest.TestCase):
     def test_good(self):
         for host, expected in [
+                    ('localhost', ['localhost']),
                     ('example.com', ['example.com']),
                     ('a.example.com', ['a.example.com', 'example.com']),
                     ('a.b.example.com', [


### PR DESCRIPTION
Like `localhost`.  These are unlikely to be portable, but they do match the [`host` ABNF][1]:

```abnf
 host          = IP-literal / IPv4address / reg-name
 reg-name      = *( unreserved / pct-encoded / sub-delims )
 unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
 pct-encoded   = "%" HEXDIG HEXDIG
 sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
               / "*" / "+" / "," / ";" / "="
```

[1]: https://tools.ietf.org/html/rfc3986#appendix-A