### PR TITLE
oci_discovery/ref_engine_discovery/__main__.py: Add --protocol and --port

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ DEBUG:oci_discovery.ref_engine.oci_index_template:received OCI index object:
  'schemaVersion': 2}
 ```
 
-Consumers who are trusting images based on the ref-engine discovery and ref-engine servers are encouraged to use `--https-only`.
+Consumers who are trusting images based on the ref-engine discovery and ref-engine servers are encouraged to use `--protocol=https`.
 
-Consumers who are trusting images based on a property of the Merkle tree (e.g. [like this][signed-name-assertions]) can safely perform ref-engine discovery and ref-resolution over HTTP, although they may still want to use `--https-only` to protect from sniffers.
+Consumers who are trusting images based on a property of the Merkle tree (e.g. [like this][signed-name-assertions]) can safely perform ref-engine discovery and ref-resolution over HTTP, although they may still want to use `--protocol=https` to protect from sniffers.
 
 ## Example: Serving everything from one Nginx server
 

--- a/oci_discovery/ref_engine_discovery/__init__.py
+++ b/oci_discovery/ref_engine_discovery/__init__.py
@@ -25,7 +25,7 @@ from . import ancestor_hosts as _ancestor_hosts
 _LOGGER = _logging.getLogger(__name__)
 
 
-def resolve(name, protocols=('https', 'http')):
+def resolve(name, protocols=('https', 'http'), port=None):
     """Resolve an image name to a Merkle root.
 
     Implementing ref-engine-discovery.md
@@ -33,6 +33,8 @@ def resolve(name, protocols=('https', 'http')):
     name_parts = _host_based_image_names.parse(name=name)
     for protocol in protocols:
         for host in _ancestor_hosts.ancestor_hosts(host=name_parts['host']):
+            if port:
+                host = '{}:{}'.format(host, port)
             uri = '{}://{}/.well-known/oci-host-ref-engines'.format(
                 protocol, host)
             _LOGGER.debug('discovering ref engines via {}'.format(uri))

--- a/oci_discovery/ref_engine_discovery/__main__.py
+++ b/oci_discovery/ref_engine_discovery/__main__.py
@@ -44,6 +44,15 @@ parser.add_argument(
         'specified (looping through all possible hosts for the first '
         'protocol, and then through all possible hosts for the second '
         'protocol, etc.).  Defaults to https,http.'))
+parser.add_argument(
+    '--port',
+    type=int,
+    help=(
+        'Port to use for ref-engine discovery.  For example, this supports '
+        'connecting to test ref-engine discovery services which are not '
+        "running on their protocol's usual port.  This option should be "
+        'combined with a single --protocol option to avoid trying multiple '
+        'protocols against the same port.'))
 
 args = parser.parse_args()
 
@@ -57,7 +66,8 @@ if args.protocol is None:
 resolved = {}
 for name in args.names:
     try:
-        resolved[name] = resolve(name=name, protocols=args.protocol)
+        resolved[name] = resolve(
+            name=name, protocols=args.protocol, port=args.port)
     except ValueError as error:
         log.error(error)
 json.dump(

--- a/oci_discovery/ref_engine_discovery/__main__.py
+++ b/oci_discovery/ref_engine_discovery/__main__.py
@@ -35,11 +35,15 @@ parser.add_argument(
     help='Log verbosity.  Defaults to {!r}.'.format(
         logging.getLevelName(log.level).lower()))
 parser.add_argument(
-    '--https-only',
-    action='store_const',
-    const=True,
-    help='Log verbosity.  Defaults to {!r}.'.format(
-        logging.getLevelName(log.level).lower()))
+    '--protocol',
+    action='append',
+    choices=['http', 'https'],
+    help=(
+        'Protocol to use for ref-engine discovery.  May be specified multiple '
+        'times, in which case the protocols will be attempted in the order '
+        'specified (looping through all possible hosts for the first '
+        'protocol, and then through all possible hosts for the second '
+        'protocol, etc.).  Defaults to https,http.'))
 
 args = parser.parse_args()
 
@@ -47,14 +51,13 @@ if args.log_level:
     level = getattr(logging, args.log_level.upper())
     log.setLevel(level)
 
-protocols = ['https']
-if not args.https_only:
-    protocols.append('http')
+if args.protocol is None:
+    args.protocol = ('https', 'http')
 
 resolved = {}
 for name in args.names:
     try:
-        resolved[name] = resolve(name=name, protocols=protocols)
+        resolved[name] = resolve(name=name, protocols=args.protocol)
     except ValueError as error:
         log.error(error)
 json.dump(


### PR DESCRIPTION
With `--protocol` replacing the old `--https-only`.  With these changes, you can do things like:

    $ python3 -m oci_discovery.ref_engine_discovery --protocol http --port 8080 '[::1]/app#1.0'

when testing locally.

Fixes #9 (although there are probably other ways we could address that too).