### PR TITLE
*: Fix “Ref-engine” → “Ref-Engine” for title-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # OCI Image Discovery Specifications
 
-This repository contains the [OCI Ref-engine Discovery specification](ref-engine-discovery.md) and related specifications as an extention to the [image specification][image-spec]:
+This repository contains the [OCI Ref-Engine Discovery specification](ref-engine-discovery.md) and related specifications as an extention to the [image specification][image-spec]:
 
 * [Host-Based Image Names](host-based-image-names.md)
     There is a [Python 3][python3] implementation in [`oci_discovery.host_based_image_names`](oci_discovery/host_based_image_names).
-* [OCI Ref-engine Discovery](ref-engine-discovery.md).
+* [OCI Ref-Engine Discovery](ref-engine-discovery.md).
     There is a Python 3 implementation in [`oci_discovery.ref_engine_discovery`](oci_discovery/ref_engine_discovery).
 * [OCI Index Template Protocol](index-template.md)
     There is a Python 3 implementation in [`oci_discovery.ref_engine.oci_index_template`](oci_discovery/ref_engine/oci_index_template).

--- a/oci_discovery/ref_engine_discovery/__main__.py
+++ b/oci_discovery/ref_engine_discovery/__main__.py
@@ -25,7 +25,7 @@ log = logging.getLogger()
 log.setLevel(logging.ERROR)
 
 parser = argparse.ArgumentParser(
-    description='Resolve image names via OCI Ref-engine Discovery.')
+    description='Resolve image names via OCI Ref-Engine Discovery.')
 parser.add_argument(
     'names', metavar='NAME', type=str, nargs='+',
     help='a host-based image name')

--- a/ref-engine-discovery.md
+++ b/ref-engine-discovery.md
@@ -1,4 +1,4 @@
-# OCI Ref-engine Discovery
+# OCI Ref-Engine Discovery
 
 This is version 0.1 of this specification.
 


### PR DESCRIPTION
For consistency with “Ref-Engine Protocols” and such.  I've only used title case for document headers (e.g. specification names); subsections use “Sentence case” headers like “Ref-engine discovery”.

This is a very minor nit, but it's easier to get consistency on these things if we are consistent from the beginning :).