### PR TITLE
oci_discovery/host_based_image_names: Improve host regexp

### DIFF
--- a/oci_discovery/host_based_image_names/__init__.py
+++ b/oci_discovery/host_based_image_names/__init__.py
@@ -16,14 +16,35 @@ import re as _re
 
 
 # The normative ABNF is in host-based-image-names.md referencing rules
-# from https://tools.ietf.org/html/rfc3986#appendix-A.  This
-# regular expression is too liberal, but will successfully match all
-# valid host-based image names.
+# from https://tools.ietf.org/html/rfc3986#appendix-A.
 _UNRESERVED_NO_HYPHEN = 'a-zA-Z0-9._~'
 _SUB_DELIMS = "!$&'()*+,;="
 _PCHAR = _UNRESERVED_NO_HYPHEN + '%' + _SUB_DELIMS + ':@' + '-'
+_DEC_OCTET = '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[05])'
+_HEXDIG = '[0-9a-fA-F]'
+_H16 = _HEXDIG + '{1,4}'
+_IPv4_ADDRESS = _DEC_OCTET + '(\.' + _DEC_OCTET + '){3}'
+IPv4_ADDRESS = _re.compile('^' + _IPv4_ADDRESS + '$')
+_LS32 = '((' + _H16 + ':' + _H16 + ')|' + _IPv4_ADDRESS + ')'
+_IPv6_ADDRESS = (
+    '(' +
+    '((' + _H16 + ':){6}' + _LS32 + ')|'
+    '(::(' + _H16 + ':){5}' + _LS32 + ')|'
+    '(' + _H16 + '?::(' + _H16 + ':){4}' + _LS32 + ')|'
+    '(((' + _H16 + ':){,1}' + _H16 + ')?::(' + _H16 + ':){3}' + _LS32 + ')|'
+    '(((' + _H16 + ':){,2}' + _H16 + ')?::(' + _H16 + ':){2}' + _LS32 + ')|'
+    '(((' + _H16 + ':){,3}' + _H16 + ')?::' + _H16 + ':' + _LS32 + ')|'
+    '(((' + _H16 + ':){,4}' + _H16 + ')?::' + _LS32 + ')|'
+    '(((' + _H16 + ':){,5}' + _H16 + ')?::' + _H16 + ')|'
+    '(((' + _H16 + ':){,6}' + _H16 + ')?::)'
+    ')')
+_IPvFUTURE = (
+    'v' + _HEXDIG + '+\.' +
+    '([' + _UNRESERVED_NO_HYPHEN + _SUB_DELIMS + ':' + '-' + '])+')
+_IP_LITERAL = r'\[(' + _IPv6_ADDRESS + '|' + _IPvFUTURE + ')]'
+_REG_NAME = '[' + _UNRESERVED_NO_HYPHEN + '%' + _SUB_DELIMS + '-]*'
 _HOST_BASED_IMAGE_NAME_REGEX = _re.compile(
-    '^(?P<host>[^/]+)'
+    '^(?P<host>' + _IP_LITERAL + '|' + _IPv4_ADDRESS + '|' + _REG_NAME + ')'
     '/'
     '(?P<path>[' + _PCHAR + ']+(/[' + _PCHAR + ']*)*)'
     '(#(?P<fragment>[/?' + _PCHAR + ']*))?$')

--- a/oci_discovery/ref_engine_discovery/ancestor_hosts.py
+++ b/oci_discovery/ref_engine_discovery/ancestor_hosts.py
@@ -15,10 +15,7 @@
 import re as _re
 
 
-# Based on rules from https://tools.ietf.org/html/rfc3986#appendix-A.
-_DEC_OCTET = '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[05])'
-_IP_V4_REGEXP = _re.compile(
-    '^' + _DEC_OCTET + '(\.' + _DEC_OCTET + '){3}$')
+from .. import host_based_image_names as _host_based_image_names
 
 
 def ancestor_hosts(host):
@@ -29,7 +26,7 @@ def ancestor_hosts(host):
     if host[0] == '[':
         yield host
         return  # no ancestor domains for IP-literals
-    match = _IP_V4_REGEXP.match(host)
+    match = _host_based_image_names.IPv4_ADDRESS.match(host)
     if match is not None:
         yield host
         return  # no ancestor domains for IPv4 addresses

--- a/oci_discovery/ref_engine_discovery/test_ancestor_hosts.py
+++ b/oci_discovery/ref_engine_discovery/test_ancestor_hosts.py
@@ -17,31 +17,6 @@ import unittest
 from . import ancestor_hosts
 
 
-class TestIPv4Detection(unittest.TestCase):
-    def test_ipv4(self):
-        for host, expected in [
-                    ('0.0.0.0', True),
-                    ('9.0.0.0', True),
-                    ('10.0.0.0', True),
-                    ('99.0.0.0', True),
-                    ('100.0.0.0', True),
-                    ('199.0.0.0', True),
-                    ('200.0.0.0', True),
-                    ('249.0.0.0', True),
-                    ('250.0.0.0', True),
-                    ('255.0.0.0', True),
-                    ('256.0.0.0', False),
-                    ('260.0.0.0', False),
-                    ('300.0.0.0', False),
-                    ('0.0.0', False),
-                    ('0.0.0.0.0', False),
-                    ('example.com', False),
-                ]:
-            with self.subTest(host=host):
-                match = ancestor_hosts._IP_V4_REGEXP.match(host)
-                self.assertEqual(match is not None, expected)
-
-
 class TestAncestorHosts(unittest.TestCase):
     def test_good(self):
         for host, expected in [


### PR DESCRIPTION
To fully implement the ABNF-defined host rule from RFC 3986.