### PR TITLE
oci_discovery/fetch_json: Return the final URI along with the JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,25 @@ $ python3 -m oci_discovery.ref_engine_discovery -l debug example.com/app#1.0 2>/
   "example.com/app#1.0": {
     "roots": [
       {
-        "annotations": {
-          "org.opencontainers.image.ref.name": "1.0"
+        "root": {
+          "annotations": {
+            "org.opencontainers.image.ref.name": "1.0"
+          },
+          "casEngines": [
+            {
+              "protocol": "oci-cas-template-v1",
+              "uri": "https://a.example.com/cas/{algorithm}/{encoded:2}/{encoded}"
+            }
+          ],
+          "digest": "sha256:e9770a03fbdccdd4632895151a93f9af58bbe2c91fdfaaf73160648d250e6ec3",
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "platform": {
+            "architecture": "ppc64le",
+            "os": "linux"
+          },
+          "size": 799
         },
-        "casEngines": [
-          {
-            "protocol": "oci-cas-template-v1",
-            "uri": "https://a.example.com/cas/{algorithm}/{encoded:2}/{encoded}"
-          }
-        ],
-        "digest": "sha256:e9770a03fbdccdd4632895151a93f9af58bbe2c91fdfaaf73160648d250e6ec3",
-        "mediaType": "application/vnd.oci.image.manifest.v1+json",
-        "platform": {
-          "architecture": "ppc64le",
-          "os": "linux"
-        },
-        "size": 799
+        "uri": "http://example.com/oci-index/app"
       }
     ]
   }

--- a/oci_discovery/fetch_json/__init__.py
+++ b/oci_discovery/fetch_json/__init__.py
@@ -13,18 +13,26 @@
 # limitations under the License.
 
 import json as _json
+import logging as _logging
 import urllib.request as _urllib_request
+
+
+_LOGGER = _logging.getLogger(__name__)
 
 
 def fetch(uri, media_type='application/json'):
     """Fetch a JSON resource."""
-    response = _urllib_request.urlopen(uri)
-    content_type = response.headers.get_content_type()
-    if content_type != media_type:
-        raise ValueError(
-            '{} returned {}, not {}'.format(uri, content_type, media_type))
-    body_bytes = response.read()
-    charset = response.headers.get_content_charset()
+    with _urllib_request.urlopen(uri) as response:
+        content_type = response.headers.get_content_type()
+        if content_type != media_type:
+            raise ValueError(
+                '{} returned {}, not {}'.format(uri, content_type, media_type))
+        body_bytes = response.read()
+        charset = response.headers.get_content_charset()
+        finalURI = response.geturl()
+    if finalURI != uri:
+        _LOGGER.debug('redirects lead from {} to {}'.format(uri, finalURI))
+        uri = finalURI
     if charset is None:
         raise ValueError('{} does not declare a charset'.format(uri))
     try:
@@ -34,6 +42,9 @@ def fetch(uri, media_type='application/json'):
             '{} returned content which did not match the declared {} charset'
             .format(uri, charset)) from error
     try:
-        return _json.loads(body)
+        return {
+            'uri': uri,
+            'json': _json.loads(body),
+        }
     except ValueError as error:
         raise ValueError('{} returned invalid JSON'.format(uri)) from error

--- a/oci_discovery/ref_engine/dummy.py
+++ b/oci_discovery/ref_engine/dummy.py
@@ -26,8 +26,9 @@ class Engine(object):
             self.__class__.__name__,
             self._response)
 
-    def __init__(self, response):
+    def __init__(self, response, base=None):
         self._response = response
+        self.base = base
 
     def resolve(self, name):
         return _copy.deepcopy(self._response)

--- a/oci_discovery/ref_engine/oci_index_template.py
+++ b/oci_discovery/ref_engine/oci_index_template.py
@@ -45,9 +45,10 @@ class Engine(object):
         if self.base:
             uri = _urllib_parse.urljoin(base=self.base, url=uri)
         _LOGGER.debug('fetching an OCI index for {} from {}'.format(name, uri))
-        index = _fetch_json.fetch(
+        fetched = _fetch_json.fetch(
             uri=uri,
             media_type='application/vnd.oci.image.index.v1+json')
+        index = fetched['json']
         _LOGGER.debug('received OCI index object:\n{}'.format(
             _pprint.pformat(index)))
         if not isinstance(index, dict):
@@ -72,4 +73,7 @@ class Engine(object):
                 'org.opencontainers.image.ref.name', None)
             if (name_parts['fragment'] == '' or
                     name_parts['fragment'] == entry_name):
-                yield entry
+                yield {
+                    'uri': fetched['uri'],
+                    'root': entry,
+                }

--- a/oci_discovery/ref_engine_discovery/__init__.py
+++ b/oci_discovery/ref_engine_discovery/__init__.py
@@ -40,7 +40,7 @@ def resolve(name, protocols=('https', 'http'), port=None):
                 protocol, host)
             _LOGGER.debug('discovering ref engines via {}'.format(uri))
             try:
-                ref_engines_object = _fetch_json.fetch(
+                fetched = _fetch_json.fetch(
                     uri=uri,
                     media_type='application/vnd.oci.ref-engines.v1+json')
             except (_ssl.CertificateError,
@@ -48,6 +48,7 @@ def resolve(name, protocols=('https', 'http'), port=None):
                     _urllib_error.URLError) as error:
                 _LOGGER.warning('failed to fetch {} ({})'.format(uri, error))
                 continue
+            ref_engines_object = fetched['json']
             _LOGGER.debug('received ref-engine discovery object:\n{}'.format(
                 _pprint.pformat(ref_engines_object)))
             if not isinstance(ref_engines_object, dict):
@@ -58,7 +59,7 @@ def resolve(name, protocols=('https', 'http'), port=None):
                 continue
             for ref_engine_object in ref_engines_object.get('refEngines', []):
                 try:
-                    ref_engine = _ref_engine.new(**ref_engine_object)
+                    ref_engine = _ref_engine.new(base=fetched['uri'], **ref_engine_object)
                 except KeyError as error:
                     _LOGGER.warning(error)
                     continue

--- a/oci_discovery/ref_engine_discovery/test.py
+++ b/oci_discovery/ref_engine_discovery/test.py
@@ -36,26 +36,48 @@ class TestResolve(unittest.TestCase):
                                 {
                                     'protocol': '_dummy',
                                     'response': [
-                                        {'name': 'dummy Merkle root 1'},
-                                        {'name': 'dummy Merkle root 2'},
+                                        {
+                                            'uri': 'https://x.example.com/y',
+                                            'root': {'name': 'dummy Merkle root 1'},
+                                        },
+                                        {
+                                            'uri': 'https://x.example.com/z',
+                                            'root': {'name': 'dummy Merkle root 2'},
+                                        },
                                     ],
                                 }
                             ]
                         },
                         {
                             'roots': [
-                                {'name': 'dummy Merkle root 1'},
-                                {'name': 'dummy Merkle root 2'},
+                                {
+                                    'uri': 'https://x.example.com/y',
+                                    'root': {'name': 'dummy Merkle root 1'},
+                                },
+                                {
+                                    'uri': 'https://x.example.com/z',
+                                    'root': {'name': 'dummy Merkle root 2'},
+                                },
                             ],
                         }
                     ),
                 ]:
+            responseURI = 'https://x.example.com/y'
             with self.subTest(label=label):
                 with unittest.mock.patch(
                         target='oci_discovery.ref_engine_discovery._fetch_json.fetch',
-                        return_value=response):
+                        return_value={
+                            'uri': responseURI,
+                            'json': response,
+                        }):
                     resolved = resolve(name=name)
-                self.assertEqual(resolved, expected)
+                self.assertEqual(
+                    resolved,
+                    [
+                        {'uri': responseURI, 'root': root}
+                        for root in expected
+                    ])
+
 
     def test_bad(self):
         for label, name, response, error, regex in [


### PR DESCRIPTION
From [here][1]:

> Note that if the retrieval was the result of a redirected request, the last URI used (i.e., the URI that resulted in the actual retrieval of the representation) is the base URI.

This fills in remaining Python functionality left off from #21.  Ref-engine discovery and ref-engine APIs now also return dicts that include a `uri` key representing this URI, which allows their consumers to also perform reference resolution.  For example, tools consuming the Merkle roots may need the URI from which those roots were extracted in order to resolve a CAS-engine URI reference.

[1]: https://tools.ietf.org/html/rfc3986#section-5.1.3