### PR TITLE
tools/refengine/root: Clear MediaType and URI if unset in JSON

### DIFF
--- a/tools/engine/config_test.go
+++ b/tools/engine/config_test.go
@@ -46,7 +46,12 @@ func TestConfigGood(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.JSON, func(t *testing.T) {
-			var config Config
+			config := Config{
+				Protocol: "initial value",
+				Data: map[string]interface{}{
+					"initial": "value",
+				},
+			}
 			json.Unmarshal([]byte(testcase.JSON), &config)
 			assert.Equal(t, testcase.Expected, config)
 			marshaled, err := json.Marshal(config)

--- a/tools/refengine/root.go
+++ b/tools/refengine/root.go
@@ -46,7 +46,9 @@ func (root *MerkleRoot) UnmarshalJSON(b []byte) (err error) {
 	}
 
 	mediaTypeInterface, ok := data["mediaType"]
-	if ok {
+	if !ok {
+		root.MediaType = ""
+	} else {
 		mediaTypeString, ok := mediaTypeInterface.(string)
 		if !ok {
 			return fmt.Errorf("merkle root mediaType is not a string: %v", mediaTypeInterface)

--- a/tools/refengine/root_test.go
+++ b/tools/refengine/root_test.go
@@ -62,7 +62,14 @@ func TestMerkleRootGood(t *testing.T) {
 		},
 	} {
 		t.Run(testcase.JSON, func(t *testing.T) {
-			var root MerkleRoot
+			root := MerkleRoot{
+				MediaType: "application/initial-value",
+				Root:      "initial value",
+				URI: &url.URL{
+					Scheme: "https",
+					Host:   "initial.value.example.com",
+				},
+			}
 			json.Unmarshal([]byte(testcase.JSON), &root)
 			assert.Equal(t, testcase.Expected, root)
 			marshaled, err := json.Marshal(root)


### PR DESCRIPTION
And add tests to confirm this.  I expect this is unlikely to matter in practice, but I think it makes sense to have the unmarshalled JSON be more like [PUT][1] than [PATCH][2].  For what it's worth, the Go implementation seems to prefer PATCH (at least as of 1.9).

Also add similar tests to `tools/engine/config_test.go`, although we didn't need changes to the implementation to get those to pass.

[1]: https://tools.ietf.org/html/rfc7231#section-4.3.4
[2]: https://tools.ietf.org/html/rfc5789