### PR TITLE
tools: Fix "ResolvedCASEngines" -> "ResolvedCASEngine" typos

### DIFF
--- a/tools/cmd/resolve.go
+++ b/tools/cmd/resolve.go
@@ -61,7 +61,7 @@ var resolveCommand = cli.Command{
 
 			err = refenginediscovery.Discover(
 				ctx, protocols, parsedName["host"],
-				func(ctx context.Context, refEngine refengine.Engine, casEngines []refenginediscovery.ResolvedCASEngines) error {
+				func(ctx context.Context, refEngine refengine.Engine, casEngines []refenginediscovery.ResolvedCASEngine) error {
 					return resolveCallback(ctx, allRoots, refEngine, casEngines, name)
 				})
 			if err == resolved {
@@ -77,7 +77,7 @@ var resolveCommand = cli.Command{
 	},
 }
 
-func resolveCallback(ctx context.Context, allRoots map[string][]refengine.MerkleRoot, refEngine refengine.Engine, casEngines []refenginediscovery.ResolvedCASEngines, name string) (err error) {
+func resolveCallback(ctx context.Context, allRoots map[string][]refengine.MerkleRoot, refEngine refengine.Engine, casEngines []refenginediscovery.ResolvedCASEngine, name string) (err error) {
 	roots, err := refEngine.Get(ctx, name)
 	if err != nil {
 		logrus.Warn(err)

--- a/tools/refenginediscovery/refenginediscovery.go
+++ b/tools/refenginediscovery/refenginediscovery.go
@@ -118,7 +118,7 @@ func (base *Base) RefEngines(ctx context.Context, refEngineCallback RefEngineCal
 			logrus.Warnf("failed to initialize %s ref engine with %v: %s", config.Protocol, config.Data, err)
 			continue
 		}
-		resolvedCASEngines := make([]ResolvedCASEngines, len(base.Config.CASEngines))
+		resolvedCASEngines := make([]ResolvedCASEngine, len(base.Config.CASEngines))
 		for i, config := range base.Config.CASEngines {
 			resolvedCASEngines[i].Config = config
 			resolvedCASEngines[i].URI = base.URI

--- a/tools/refenginediscovery/type.go
+++ b/tools/refenginediscovery/type.go
@@ -46,7 +46,7 @@ type Base struct {
 
 // ResolvedCASEngine holds a CAS-engine configuration and the URI
 // from which it was retrieved.
-type ResolvedCASEngines struct {
+type ResolvedCASEngine struct {
 
 	// Config the CAS-engine configuration.
 	Config engine.Config
@@ -58,4 +58,4 @@ type ResolvedCASEngines struct {
 }
 
 // RefEngineCallback templates a callback for use in RefEngines.
-type RefEngineCallback func(ctx context.Context, refEngine refengine.Engine, casEngines []ResolvedCASEngines) (err error)
+type RefEngineCallback func(ctx context.Context, refEngine refengine.Engine, casEngines []ResolvedCASEngine) (err error)


### PR DESCRIPTION
We usually use this type in arrays, but the type itself represents a single CAS-engine config.