### PR TITLE
tools/cmd/resolve: Keep iterating through ref-engines on empty Get

### DIFF
--- a/tools/cmd/resolve.go
+++ b/tools/cmd/resolve.go
@@ -83,6 +83,9 @@ func resolveCallback(ctx context.Context, allRoots map[string][]refengine.Merkle
 		logrus.Warn(err)
 		return nil
 	}
+	if len(roots) == 0 {
+		return nil
+	}
 	allRoots[name] = roots
 	return resolved
 }

--- a/tools/refengine/interface.go
+++ b/tools/refengine/interface.go
@@ -24,6 +24,8 @@ import (
 type Engine interface {
 
 	// Get returns an array of potential Merkle roots from the store.
+	// When no results are found, roots will be an empty array and err
+	// will be nil.
 	Get(ctx context.Context, name string) (roots []MerkleRoot, err error)
 
 	// Close releases resources held by the engine.  Subsequent engine


### PR DESCRIPTION
If the ref-engine we're checking returns no results, keep going (even if it didn't return an error).  Also document the “ref-engine knows it doesn't have that name” results in the `Engine.Get` interface.