### PR TITLE
.mailmap: Consilidate Keyang's emails

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+xiekeyang <xiekeyang@huawei.com> <keyang.xie@gmail.com>
+xiekeyang <xiekeyang@huawei.com> <xiekeyang@users.noreply.github.com>


### PR DESCRIPTION
Preferring the most common commit author:

    $ git log --no-merges | grep '^Author.*keyang' | sort | uniq -c | sort -n | tail -n1
        5 Author: xiekeyang <xiekeyang@huawei.com>

Docs for the format in the MAPPING AUTHORS section of `git-shortlog(1)`.