### PR TITLE
xdg-ref-engine-discovery: Add an XDG ref-engine discovery protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # OCI Image Discovery Specifications
 
-This repository contains a [ref-engine discovery](glossary.md#ref-engine-discovery) specification:
+This repository contains two [ref-engine discovery](glossary.md#ref-engine-discovery) specifications:
 
 * [OCI Well Known URI Ref-Engine Discovery](well-known-uri-ref-engine-discovery.md).
     There is a [Go][] implementation in [`tools/refenginediscovery/wellknownuri`](tools/refenginediscovery/wellknownuri).
     There is a [Python 3][python3] implementation in [`oci_discovery.ref_engine_discovery`](oci_discovery/ref_engine_discovery).
+* [OCI XDG Ref-Engine Discovery](xdg-ref-engine-discovery.md).
+    There is a Go implementation in [`tools/refenginediscovery/xdg`](tools/refenginediscovery/xdg).
 
 This repository also contains some related specifications:
 
@@ -16,7 +18,7 @@ This repository also contains some related specifications:
     There is a Python 3 implementation in [`oci_discovery.ref_engine.oci_index_template`](oci_discovery/ref_engine/oci_index_template).
 * [OCI CAS Template Protocol](cas-template.md)
 
-This repository also contains registries for ref- and CAS-engine protocols:
+This repository also contains registries for [ref-](glossary.md#ref-engine) and [CAS-engine](glossary.md#cas-engine) protocols:
 
 * [Ref-Engine Protocols](ref-engine-prococols.md).
     There is a Go implemention in [`tools/refengine`](tools/refengine).

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ http {
 }
 ```
 
-Then in `/srv/example.com/.well-known/oci-host-ref-engines`, the following [ref-engines object](well-known-uri-ref-engine-discovery.md#ref-engines-objects):
+Then in `/srv/example.com/.well-known/oci-host-ref-engines`, the following [ref-engines object](xdg-ref-engines-discovery.md#ref-engines-objects):
 
 ```json
 {
@@ -245,7 +245,7 @@ All the CAS blobs can go in the same bucket under `/srv/example.com/oci-cas`, al
 ## Example: Serving OCI layouts from Nginx
 
 As an alternative to the [previous example](#example-serving-everything-from-one-nginx-server), you can bucket your CAS blobs by serving [OCI layouts][layout] directly.
-If your layout `index.json` are not setting `casEngines` and you are unwilling to update them to do so, you can [set `casEngines` in you ref-engines object](well-known-uri-ref-engine-discovery.md#ref-engines-objects) at `/srv/example.com/.well-known/oci-host-ref-engines`:
+If your layout `index.json` are not setting `casEngines` and you are unwilling to update them to do so, you can [set `casEngines` in you ref-engines object](xdg-ref-engines-discovery.md#ref-engines-objects) at `/srv/example.com/.well-known/oci-host-ref-engines`:
 
 ```json
 {

--- a/cas-template.md
+++ b/cas-template.md
@@ -3,7 +3,7 @@
 This is version 1 of this specification.
 
 The CAS-template protocol is configured via a single [URI Template][rfc6570].
-When configured via a [`casEngines` entry](well-known-uri-ref-engine-discovery.md#ref-engines-objects), the `uri` property MUST be set, and its value is the URI Template.
+When configured via a [`casEngines` entry](xdg-ref-engine-discovery.md#ref-engines-objects), the `uri` property MUST be set, and its value is the URI Template.
 
 For a given blob digest, consumers MUST provide at least the following variables:
 
@@ -16,7 +16,7 @@ If the expanded URI reference is a relative reference, it MUST be resolved follo
 
 ## Example
 
-An example [`casEngines` entry](well-known-uri-ref-engine-discovery.md#ref-engines-objects) using the [registered `oci-cas-template-v1` protocol identifier](cas-engine-protocols.md) is:
+An example [`casEngines` entry](xdg-ref-engine-discovery.md#ref-engines-objects) using the [registered `oci-cas-template-v1` protocol identifier](cas-engine-protocols.md) is:
 
 ```json
 {

--- a/index-template.md
+++ b/index-template.md
@@ -3,7 +3,7 @@
 This is version 1 of this specification.
 
 The index-template protocol is configured via a single [URI Template][rfc6570].
-When configured via a [`refEngines` entry](well-known-uri-ref-engine-discovery.md#ref-engines-objects), the `uri` property MUST be set, and its value is the URI Template.
+When configured via a [`refEngines` entry](xdg-ref-engines-discovery.md#ref-engines-objects), the `uri` property MUST be set, and its value is the URI Template.
 
 Consumers MUST provide at least the following variables:
 
@@ -23,7 +23,7 @@ Consumers retrieving `application/vnd.oci.image.index.v1+json` SHOULD process it
 
 ## Example
 
-An example [`refEngines` entry](well-known-uri-ref-engine-discovery.md#ref-engines-objects) using the [registered `oci-index-template-v1` protocol identifier](ref-engine-protocols.md) is:
+An example [`refEngines` entry](xdg-ref-engines-discovery.md#ref-engines-objects) using the [registered `oci-index-template-v1` protocol identifier](ref-engine-protocols.md) is:
 
 ```json
 {

--- a/ref-engine-protocols.md
+++ b/ref-engine-protocols.md
@@ -1,7 +1,7 @@
 # Ref-Engine Protocols
 
 There are many possible [ref-engine](glossary.md#ref-engine) protocols.
-Having identifiers for the protocols facilitates [ref-engine discovery](glossary.md#ref-engine-discovery) by allowing discovery services to [describe the protocol for suggested ref engines](well-known-uri-ref-engine-discovery.md#ref-engines-objects).
+Having identifiers for the protocols facilitates [ref-engine discovery](glossary.md#ref-engine-discovery) by allowing discovery services to describe the protocol for suggested ref engines (e.g. as declared in a [ref-engines object](xdg-ref-engine-discovery.md#ref-engines-objects)).
 Consumers can then prefer ref engines which implement their favorite protocol and use the appropriate API to connect to them.
 
 This section registers known protocol identifiers and maps them to their specification.

--- a/ref-engine-protocols.md
+++ b/ref-engine-protocols.md
@@ -1,7 +1,7 @@
 # Ref-Engine Protocols
 
-There are many possible [ref-engine](ref-engine-discovery.md#ref-engine) protocols.
-Having identifiers for the protocols facilitates [ref-engine discovery](ref-engine-discovery.md#ref-engine-discovery) by allowing discovery services to [describe the protocol for suggested ref engines](ref-engine-discovery.md#ref-engines-objects).
+There are many possible [ref-engine](glossary.md#ref-engine) protocols.
+Having identifiers for the protocols facilitates [ref-engine discovery](glossary.md#ref-engine-discovery) by allowing discovery services to [describe the protocol for suggested ref engines](well-known-uri-ref-engine-discovery.md#ref-engines-objects).
 Consumers can then prefer ref engines which implement their favorite protocol and use the appropriate API to connect to them.
 
 This section registers known protocol identifiers and maps them to their specification.

--- a/tools/refenginediscovery/engines.go
+++ b/tools/refenginediscovery/engines.go
@@ -21,15 +21,17 @@ import (
 	"golang.org/x/net/context"
 )
 
-// ResolvedNameCallback templates a callback for use in Discover.
+// ResolvedNameCallback templates a callback for use in ResolveName.
 type ResolvedNameCallback func(ctx context.Context, root refengine.MerkleRoot, casEngines []engine.Reference) (err error)
 
-// FIXME: ResolveName calculates ref engines using Ref-Engine Discovery and
-// calls RefEngines on each one.  Discover returns any errors returned
-// by RefEngines and aborts further iteration.  Other errors (e.g. in
-// fetching a ref-engine discovery object from a particular
-// protocol/host pair) generate logged warnings but are otherwise
-// ignored.
+// ResolveName iterates over engines calling Engine.RefEngines to get
+// potential ref-engine configs.  Then it iterates over those
+// ref-engine configs, instantiates a ref engine, and queries that ref
+// engine for matching Merkle roots, calling resolvedNameCallback on
+// each one.  ResolveName returns any errors returned by
+// resolvedNameCallback and aborts further iteration.  Other errors
+// (e.g. in initializing a ref engine) generate logged warnings but
+// are otherwise ignored.
 func ResolveName(ctx context.Context, engines []Engine, name string, resolvedNameCallback ResolvedNameCallback) (err error) {
 	for _, engine := range engines {
 		err = engine.RefEngines(

--- a/tools/refenginediscovery/wellknownuri/wellknownuri.go
+++ b/tools/refenginediscovery/wellknownuri/wellknownuri.go
@@ -25,6 +25,7 @@ import (
 	"github.com/xiekeyang/oci-discovery/tools/engine"
 	"github.com/xiekeyang/oci-discovery/tools/hostbasedimagenames"
 	"github.com/xiekeyang/oci-discovery/tools/refenginediscovery"
+	"github.com/xiekeyang/oci-discovery/tools/refenginediscovery/xdg"
 	"golang.org/x/net/context"
 )
 
@@ -72,18 +73,18 @@ func (eng *Engine) RefEngines(ctx context.Context, name string, refEngineCallbac
 			continue
 		}
 		var casEngines []engine.Reference
-		if reference.engines.CASEngines != nil {
-			casEngines = make([]engine.Reference, len(reference.engines.CASEngines))
-			for i, config := range reference.engines.CASEngines {
+		if reference.Engines.CASEngines != nil {
+			casEngines = make([]engine.Reference, len(reference.Engines.CASEngines))
+			for i, config := range reference.Engines.CASEngines {
 				casEngines[i].Config = config
-				casEngines[i].URI = reference.uri
+				casEngines[i].URI = reference.URI
 			}
 		}
-		for _, config := range reference.engines.RefEngines {
+		for _, config := range reference.Engines.RefEngines {
 			ref := refenginediscovery.Reference{
 				Config: engine.Reference{
 					Config: config,
-					URI:    reference.uri,
+					URI:    reference.URI,
 				},
 				CASEngines: casEngines,
 			}
@@ -102,7 +103,7 @@ func (eng *Engine) Close(ctx context.Context) (err error) {
 	return nil
 }
 
-func (eng *Engine) fetch(ctx context.Context, uri *url.URL) (ref *reference, err error) {
+func (eng *Engine) fetch(ctx context.Context, uri *url.URL) (ref *xdg.Reference, err error) {
 	request := &http.Request{
 		Method: "GET",
 		URL:    uri,
@@ -133,10 +134,10 @@ func (eng *Engine) fetch(ctx context.Context, uri *url.URL) (ref *reference, err
 		return nil, fmt.Errorf("requested %s from %s but got %s", request.Header.Get(`Accept`), request.URL, mediatype)
 	}
 
-	ref = &reference{
-		uri: uri, // FIXME: get URI after any redirects
+	ref = &xdg.Reference{
+		URI: uri, // FIXME: get URI after any redirects
 	}
-	if err := json.NewDecoder(response.Body).Decode(&ref.engines); err != nil {
+	if err := json.NewDecoder(response.Body).Decode(&ref.Engines); err != nil {
 		logrus.Errorf("ref engines object decoded failed: %s", err)
 		return nil, err
 	}

--- a/tools/refenginediscovery/xdg/stringlengthsort.go
+++ b/tools/refenginediscovery/xdg/stringlengthsort.go
@@ -1,0 +1,43 @@
+// Copyright 2017 oci-discovery contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdg
+
+// stringLengthSort implements sort.Interface to order an array of
+// strings by decreasing length.  Length ties are broken by byte
+// order.
+type stringLengthSort []string
+
+// Len is the number of elements in the collection.
+func (s stringLengthSort) Len() int {
+	return len(s)
+}
+
+// Less reports whether the element with index i should sort before
+// the element with index j.
+func (s stringLengthSort) Less(i, j int) bool {
+	leni := len(s[i])
+	lenj := len(s[j])
+	if leni > lenj {
+		return true
+	} else if leni == lenj {
+		return s[i] < s[j]
+	}
+	return false
+}
+
+// Swap swaps the elements with indexes i and j.
+func (s stringLengthSort) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/tools/refenginediscovery/xdg/stringlengthsort_test.go
+++ b/tools/refenginediscovery/xdg/stringlengthsort_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017 oci-discovery contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdg
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSort(t *testing.T) {
+	for _, testcase := range []struct {
+		name     string
+		values   []string
+		expected []string
+	}{
+		{
+			name:     "empty array",
+			values:   nil,
+			expected: nil,
+		},
+		{
+			name:     "entries of different lengths",
+			values:   []string{"a", "abc", "bc"},
+			expected: []string{"abc", "bc", "a"},
+		},
+		{
+			name:     "entries with the same length",
+			values:   []string{"b", "a", "bc"},
+			expected: []string{"bc", "a", "b"},
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			sort.Sort(stringLengthSort(testcase.values))
+			assert.Equal(t, testcase.expected, testcase.values)
+		})
+	}
+}

--- a/tools/refenginediscovery/xdg/type.go
+++ b/tools/refenginediscovery/xdg/type.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package wellknownuri
+package xdg
 
 import (
 	"net/url"
@@ -30,14 +30,14 @@ type Engines struct {
 	CASEngines []engine.Config `json:"casEngines,omitempty"`
 }
 
-// reference holds resolved Engines data.
-type reference struct {
+// Reference holds resolved Engines data.
+type Reference struct {
 
-	// engines holds the resolved Engines declaration.
-	engines Engines
+	// Engines holds the resolved Engines declaration.
+	Engines Engines
 
-	// uri is the source, if any, from which Engines was retrieved.  It
+	// URI is the source, if any, from which Engines was retrieved.  It
 	// can be used to expand any relative reference contained within
 	// Engines.
-	uri *url.URL
+	URI *url.URL
 }

--- a/tools/refenginediscovery/xdg/xdg.go
+++ b/tools/refenginediscovery/xdg/xdg.go
@@ -1,0 +1,125 @@
+// Copyright 2017 oci-discovery contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdg
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+
+	"github.com/BurntSushi/xdg"
+	"github.com/sirupsen/logrus"
+	"github.com/xiekeyang/oci-discovery/tools/engine"
+	"github.com/xiekeyang/oci-discovery/tools/refenginediscovery"
+	"github.com/xiekeyang/oci-discovery/tools/refenginediscovery/wellknownuri"
+	"golang.org/x/net/context"
+)
+
+// Engine implements the XDG Ref-Engine Discovery protocol.
+type Engine struct {
+	xdgPaths xdg.Paths
+}
+
+// New creates a new ref-engine-discovery instance.
+func New(ctx context.Context, xdgPaths xdg.Paths) (engine refenginediscovery.Engine, err error) {
+	return &Engine{
+		xdgPaths: xdgPaths,
+	}, nil
+}
+
+// RefEngines calculates ref engines using the XDG Ref-Engine
+// Discovery Protocol and calls refEngineCallback on each one.
+// RefEngines returns any errors returned by refEngineCallback and
+// aborts further iteration.  Other errors (e.g. in fetching a
+// configuration from the filesystem) generate logged warnings but are
+// otherwise ignored.
+func (eng *Engine) RefEngines(ctx context.Context, name string, refEngineCallback refenginediscovery.RefEngineCallback) (err error) {
+	path, err := eng.xdgPaths.ConfigFile("ref-engine-discovery.json")
+	if err != nil {
+		logrus.Warn(err)
+		return nil
+	}
+	// FIXME: iterate through lower-preference paths
+	// https://github.com/BurntSushi/xdg/issues/3
+
+	uriString := fmt.Sprintf("file://" + path) // FIXME: Convert Windows separators
+	uri, err := url.Parse(uriString)
+	if err != nil {
+		logrus.Warn(err)
+		return nil
+	}
+
+	logrus.Debugf("requesting application/vnd.oci.regexp-ref-engines.v1+json from %s", uri)
+	file, err := os.Open(path)
+	if err != nil {
+		logrus.Warn(err)
+		return nil
+	}
+	defer file.Close()
+
+	var data map[string]wellknownuri.Engines
+	err = json.NewDecoder(file).Decode(&data)
+	if err != nil {
+		logrus.Warn(err)
+		return nil
+	}
+
+	patterns := []string{}
+	for pattern := range data {
+		patterns = append(patterns, pattern)
+	}
+	sort.Sort(stringLengthSort(patterns))
+
+	for _, pattern := range patterns {
+		pat, err := regexp.Compile(pattern)
+		if err != nil {
+			logrus.Warn(err)
+			continue
+		}
+		if pat.MatchString(name) {
+			var casEngines []engine.Reference
+			if data[pattern].CASEngines != nil {
+				casEngines = make([]engine.Reference, len(data[pattern].CASEngines))
+				for i, config := range data[pattern].CASEngines {
+					casEngines[i].Config = config
+					casEngines[i].URI = uri
+				}
+			}
+			for _, config := range data[pattern].RefEngines {
+				ref := refenginediscovery.Reference{
+					Config: engine.Reference{
+						Config: config,
+						URI:    uri,
+					},
+					CASEngines: casEngines,
+				}
+				err = refEngineCallback(ctx, ref)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// Close releases resources held by the engine.
+func (eng *Engine) Close(ctx context.Context) (err error) {
+	return nil
+}

--- a/tools/refenginediscovery/xdg/xdg_test.go
+++ b/tools/refenginediscovery/xdg/xdg_test.go
@@ -1,0 +1,452 @@
+// Copyright 2017 oci-discovery contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdg
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/BurntSushi/xdg"
+	"github.com/stretchr/testify/assert"
+	"github.com/xiekeyang/oci-discovery/tools/engine"
+	"github.com/xiekeyang/oci-discovery/tools/refenginediscovery"
+	"golang.org/x/net/context"
+)
+
+func TestNewGood(t *testing.T) {
+	ctx := context.Background()
+	engine, err := New(ctx, xdg.Paths{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = engine.Close(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRefEnginesGood(t *testing.T) {
+	ctx := context.Background()
+	for _, testcase := range []struct {
+		label            string
+		regexpRefEngines map[string]Reference
+		name             string
+		expected         []refenginediscovery.Reference
+	}{
+		{
+			label:            "nil regexpRefEngines",
+			regexpRefEngines: nil,
+			name:             "example",
+			expected:         []refenginediscovery.Reference{},
+		},
+		{
+			label: "no matching regexps",
+			regexpRefEngines: map[string]Reference{
+				"^app$": Reference{
+					Engines: Engines{
+						RefEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-image-template-v1",
+								Data: map[string]interface{}{
+									"uri": "index.json",
+								},
+							},
+						},
+					},
+					URI: &url.URL{
+						Scheme: "https",
+						Host:   "example.com",
+					},
+				},
+			},
+			name:     "example",
+			expected: []refenginediscovery.Reference{},
+		},
+		{
+			label: "single matching regexp with one ref-engine config",
+			regexpRefEngines: map[string]Reference{
+				"^app$": Reference{
+					Engines: Engines{
+						RefEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-image-template-v1",
+								Data: map[string]interface{}{
+									"uri": "index.json",
+								},
+							},
+						},
+					},
+					URI: &url.URL{
+						Scheme: "https",
+						Host:   "example.com",
+					},
+				},
+			},
+			name: "app",
+			expected: []refenginediscovery.Reference{
+				refenginediscovery.Reference{
+					Config: engine.Reference{
+						Config: engine.Config{
+							Protocol: "oci-image-template-v1",
+							Data: map[string]interface{}{
+								"uri": "index.json",
+							},
+						},
+						URI: &url.URL{
+							Scheme: "https",
+							Host:   "example.com",
+						},
+					},
+				},
+			},
+		},
+		{
+			label: "single matching regexp with one ref-engine and one CAS-engine config",
+			regexpRefEngines: map[string]Reference{
+				"^app$": Reference{
+					Engines: Engines{
+						RefEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-image-template-v1",
+								Data: map[string]interface{}{
+									"uri": "index.json",
+								},
+							},
+						},
+						CASEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-cas-template-v1",
+								Data: map[string]interface{}{
+									"uri": "/{algorithm}/{encoded}",
+								},
+							},
+						},
+					},
+					URI: &url.URL{
+						Scheme: "https",
+						Host:   "example.com",
+					},
+				},
+			},
+			name: "app",
+			expected: []refenginediscovery.Reference{
+				refenginediscovery.Reference{
+					Config: engine.Reference{
+						Config: engine.Config{
+							Protocol: "oci-image-template-v1",
+							Data: map[string]interface{}{
+								"uri": "index.json",
+							},
+						},
+						URI: &url.URL{
+							Scheme: "https",
+							Host:   "example.com",
+						},
+					},
+					CASEngines: []engine.Reference{
+						engine.Reference{
+							Config: engine.Config{
+								Protocol: "oci-cas-template-v1",
+								Data: map[string]interface{}{
+									"uri": "/{algorithm}/{encoded}",
+								},
+							},
+							URI: &url.URL{
+								Scheme: "https",
+								Host:   "example.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			label: "two matching regexps of different length",
+			regexpRefEngines: map[string]Reference{
+				"^app$": Reference{
+					Engines: Engines{
+						RefEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-image-template-v1",
+								Data: map[string]interface{}{
+									"uri": "index.json",
+								},
+							},
+						},
+						CASEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-cas-template-v1",
+								Data: map[string]interface{}{
+									"uri": "/{algorithm}/{encoded}",
+								},
+							},
+						},
+					},
+					URI: &url.URL{
+						Scheme: "https",
+						Host:   "example.com",
+					},
+				},
+				"^ap.*$": Reference{
+					Engines: Engines{
+						RefEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-image-template-v1",
+								Data: map[string]interface{}{
+									"uri": "/other-index",
+								},
+							},
+						},
+					},
+					URI: &url.URL{
+						Scheme: "file",
+						Path:   "/example",
+					},
+				},
+			},
+			name: "app",
+			expected: []refenginediscovery.Reference{
+				refenginediscovery.Reference{
+					Config: engine.Reference{
+						Config: engine.Config{
+							Protocol: "oci-image-template-v1",
+							Data: map[string]interface{}{
+								"uri": "/other-index",
+							},
+						},
+						URI: &url.URL{
+							Scheme: "file",
+							Path:   "/example",
+						},
+					},
+				},
+				refenginediscovery.Reference{
+					Config: engine.Reference{
+						Config: engine.Config{
+							Protocol: "oci-image-template-v1",
+							Data: map[string]interface{}{
+								"uri": "index.json",
+							},
+						},
+						URI: &url.URL{
+							Scheme: "https",
+							Host:   "example.com",
+						},
+					},
+					CASEngines: []engine.Reference{
+						engine.Reference{
+							Config: engine.Config{
+								Protocol: "oci-cas-template-v1",
+								Data: map[string]interface{}{
+									"uri": "/{algorithm}/{encoded}",
+								},
+							},
+							URI: &url.URL{
+								Scheme: "https",
+								Host:   "example.com",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			label: "two matching regexps of same length",
+			regexpRefEngines: map[string]Reference{
+				"^ap.$": Reference{
+					Engines: Engines{
+						RefEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-image-template-v1",
+								Data: map[string]interface{}{
+									"uri": "index.json",
+								},
+							},
+						},
+						CASEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-cas-template-v1",
+								Data: map[string]interface{}{
+									"uri": "/{algorithm}/{encoded}",
+								},
+							},
+						},
+					},
+					URI: &url.URL{
+						Scheme: "https",
+						Host:   "example.com",
+					},
+				},
+				"^app$": Reference{
+					Engines: Engines{
+						RefEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-image-template-v1",
+								Data: map[string]interface{}{
+									"uri": "/other-index",
+								},
+							},
+						},
+					},
+					URI: &url.URL{
+						Scheme: "file",
+						Path:   "/example",
+					},
+				},
+			},
+			name: "app",
+			expected: []refenginediscovery.Reference{
+				refenginediscovery.Reference{
+					Config: engine.Reference{
+						Config: engine.Config{
+							Protocol: "oci-image-template-v1",
+							Data: map[string]interface{}{
+								"uri": "index.json",
+							},
+						},
+						URI: &url.URL{
+							Scheme: "https",
+							Host:   "example.com",
+						},
+					},
+					CASEngines: []engine.Reference{
+						engine.Reference{
+							Config: engine.Config{
+								Protocol: "oci-cas-template-v1",
+								Data: map[string]interface{}{
+									"uri": "/{algorithm}/{encoded}",
+								},
+							},
+							URI: &url.URL{
+								Scheme: "https",
+								Host:   "example.com",
+							},
+						},
+					},
+				},
+				refenginediscovery.Reference{
+					Config: engine.Reference{
+						Config: engine.Config{
+							Protocol: "oci-image-template-v1",
+							Data: map[string]interface{}{
+								"uri": "/other-index",
+							},
+						},
+						URI: &url.URL{
+							Scheme: "file",
+							Path:   "/example",
+						},
+					},
+				},
+			},
+		},
+		{
+			label: "invalid regexp ignored",
+			regexpRefEngines: map[string]Reference{
+				"[": Reference{
+					Engines: Engines{
+						RefEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-image-template-v1",
+								Data: map[string]interface{}{
+									"uri": "index.json",
+								},
+							},
+						},
+					},
+					URI: &url.URL{
+						Scheme: "https",
+						Host:   "example.com",
+					},
+				},
+				"^app$": Reference{
+					Engines: Engines{
+						RefEngines: []engine.Config{
+							engine.Config{
+								Protocol: "oci-image-template-v1",
+								Data: map[string]interface{}{
+									"uri": "index.json",
+								},
+							},
+						},
+					},
+					URI: &url.URL{
+						Scheme: "https",
+						Host:   "example.com",
+					},
+				},
+			},
+			name: "app",
+			expected: []refenginediscovery.Reference{
+				refenginediscovery.Reference{
+					Config: engine.Reference{
+						Config: engine.Config{
+							Protocol: "oci-image-template-v1",
+							Data: map[string]interface{}{
+								"uri": "index.json",
+							},
+						},
+						URI: &url.URL{
+							Scheme: "https",
+							Host:   "example.com",
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(testcase.label, func(t *testing.T) {
+			refEngines := []refenginediscovery.Reference{}
+			err := RefEngines(ctx, testcase.regexpRefEngines, testcase.name, func(ctx context.Context, refEngine refenginediscovery.Reference) error {
+				refEngines = append(refEngines, refEngine)
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, testcase.expected, refEngines)
+		})
+	}
+}
+
+func TestRefEnginesCallbackError(t *testing.T) {
+	ctx := context.Background()
+	regexpRefEngines := map[string]Reference{
+		"^app$": Reference{
+			Engines: Engines{
+				RefEngines: []engine.Config{
+					engine.Config{
+						Protocol: "oci-image-template-v1",
+						Data: map[string]interface{}{
+							"uri": "index.json",
+						},
+					},
+				},
+			},
+			URI: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+			},
+		},
+	}
+	testError := fmt.Errorf("testing")
+	err := RefEngines(ctx, regexpRefEngines, "app", func(ctx context.Context, refEngine refenginediscovery.Reference) error {
+		return testError
+	})
+	assert.Equal(t, testError, err)
+}

--- a/well-known-uri-ref-engine-discovery.md
+++ b/well-known-uri-ref-engine-discovery.md
@@ -34,24 +34,8 @@ For example, if the `host` extracted from the image name is `a.b.example.com` an
 
 ## Ref-engines media types
 
-Servers supporting the [`oci-host-ref-engines` URI](#oci-host-ref-engines-well-known-uri-registration) MUST support requests for media type [`application/vnd.oci.ref-engines.v1+json`](#ref-engines-objects).
+Servers supporting the [`oci-host-ref-engines` URI](#oci-host-ref-engines-well-known-uri-registration) MUST support requests for media type [`application/vnd.oci.ref-engines.v1+json`](xdg-ref-engines-discovery.md#ref-engines-objects).
 Servers MAY support other media types using HTTP content negotiation, as described in [RFC 7231 section 3.4][rfc7231-s3.4] (which is [also supported over HTTP/2][rfc7540-s8]).
-
-## Ref-engines objects
-
-This section defines the `application/vnd.oci.ref-engines.v1+json` [media type][media-type].
-Content of this type MUST be a JSON object, as defined in [RFC 7159 section 4][rfc7159-s4].
-The object MAY include a `refEngines` entry.
-If set, the `refEngines` entry MUST be an [array][rfc7159-s5].
-Each entry in the `refEngines` array MUST be an [objects][rfc7159-s4] with at least a `protocol` entry specifying the [ref-engine protocol](ref-engine-protocols.md).
-Consumers SHOULD ignore entries which declare unsupported `protocol` values.
-The order of entries in the array is not significant.
-
-The ref-engine discovery service MAY also include `casEngines` entry if it wants to supplement suggestions made by the ref engines.
-If set, the `casEngines` entry MUST be an [array][rfc7159-s5].
-Each entry in the `casEngines` array MUST be an [objects][rfc7159-s4] with at least a `protocol` entry specifying the [CAS-engine protocol](cas-engine-protocols.md).
-Consumers SHOULD ignore entries which declare unsupported `protocol` values.
-The order of entries in the array is not significant.
 
 ### Example 1
 

--- a/well-known-uri-ref-engine-discovery.md
+++ b/well-known-uri-ref-engine-discovery.md
@@ -36,6 +36,7 @@ For example, if the `host` extracted from the image name is `a.b.example.com` an
 
 Servers supporting the [`oci-host-ref-engines` URI](#oci-host-ref-engines-well-known-uri-registration) MUST support requests for media type [`application/vnd.oci.ref-engines.v1+json`](xdg-ref-engines-discovery.md#ref-engines-objects).
 Servers MAY support other media types using HTTP content negotiation, as described in [RFC 7231 section 3.4][rfc7231-s3.4] (which is [also supported over HTTP/2][rfc7540-s8]).
+For example, servers MAY support [`application/vnd.oci.regexp-ref-engines.v1+json`](xdg-ref-engines-discovery.md#regexp-ref-engines-objects) to provide more targetted suggestions about specific subsets of image names.
 
 ### Example 1
 

--- a/xdg-ref-engine-discovery.md
+++ b/xdg-ref-engine-discovery.md
@@ -8,12 +8,28 @@ Having retrieved a set of reference engines (via this and other protocols), cons
 Consumers who choose not to support this specification can safely ignore the remainder of this document.
 Consumers who choose to support this specification MAY attempt to discover and use ref engines via other channels, and only fall back to this protocol if those ref engines do not return a satisfactory Merkle root.
 
+## Ref-engines objects
+
+This section defines the `application/vnd.oci.ref-engines.v1+json` [media type][media-type].
+Content of this type MUST be a JSON object, as defined in [RFC 7159 section 4][rfc7159-s4].
+The object MAY include a `refEngines` entry.
+If set, the `refEngines` entry MUST be an [array][rfc7159-s5].
+Each entry in the `refEngines` array MUST be an [objects][rfc7159-s4] with at least a `protocol` entry specifying the [ref-engine protocol](ref-engine-protocols.md).
+Consumers SHOULD ignore entries which declare unsupported `protocol` values.
+The order of entries in the array is not significant.
+
+The ref-engine discovery service MAY also include `casEngines` entry if it wants to supplement suggestions made by the ref engines.
+If set, the `casEngines` entry MUST be an [array][rfc7159-s5].
+Each entry in the `casEngines` array MUST be an [objects][rfc7159-s4] with at least a `protocol` entry specifying the [CAS-engine protocol](cas-engine-protocols.md).
+Consumers SHOULD ignore entries which declare unsupported `protocol` values.
+The order of entries in the array is not significant.
+
 ## Regexp ref-engines objects
 
 This section defines the `application/vnd.oci.regexp-ref-engines.v1+json` [media type][media-type].
 Content of this type MUST be a JSON object, as defined in [RFC 7159 section 4][rfc7159-s4].
 Keys MUST be Extended Regular Expressions, as defined in [IEEE Std 1003.1-2008][ERE].
-Values MUST be JSON objects that conform to the [`application/vnd.oci.ref-engines.v1+json` media type](well-known-uri-ref-engine-discovery.md#ref-engines-objects).
+Values MUST be JSON objects that conform to the [`application/vnd.oci.ref-engines.v1+json` media type](#ref-engines-objects).
 
 For a given image name, consumers SHOULD treat all keys that match the image name as valid.
 When multiple keys match the image name, consumers SHOULD prefer the regexp with the longest length.

--- a/xdg-ref-engine-discovery.md
+++ b/xdg-ref-engine-discovery.md
@@ -1,0 +1,72 @@
+# OCI XDG Ref-Engine Discovery
+
+This is version 0.1 of this specification.
+
+To faciliate local control over image resolution, this specification defines a [ref-engine discovery](glossary.md#ref-engine-discovery) protocol which consumers and their local sysadmins MAY use to provide local [reference engine](glossary.md#ref-engine) suggestions for particular image names.
+
+Having retrieved a set of reference engines (via this and other protocols), consumers can use those ref engines to recover a set of [Merkle roots](glossary.md#merkle-root) potentially associated with a given image name.
+Consumers who choose not to support this specification can safely ignore the remainder of this document.
+Consumers who choose to support this specification MAY attempt to discover and use ref engines via other channels, and only fall back to this protocol if those ref engines do not return a satisfactory Merkle root.
+
+## Regexp ref-engines objects
+
+This section defines the `application/vnd.oci.regexp-ref-engines.v1+json` [media type][media-type].
+Content of this type MUST be a JSON object, as defined in [RFC 7159 section 4][rfc7159-s4].
+Keys MUST be Extended Regular Expressions, as defined in [IEEE Std 1003.1-2008][ERE].
+Values MUST be JSON objects that conform to the [`application/vnd.oci.ref-engines.v1+json` media type](well-known-uri-ref-engine-discovery.md#ref-engines-objects).
+
+For a given image name, consumers SHOULD treat all keys that match the image name as valid.
+When multiple keys match the image name, consumers SHOULD prefer the regexp with the longest length.
+When multiple keys of the same length match the image name, consumers SHOULD prefer the regexp which sorts earlier according to `LC_COLLATE` in the POSIX locale, as defined in [IEEE Std 1003.1-2008][POSIX-LC_COLLATE].
+
+## XDG representation
+
+Consumers discovering ref engines for an image name SHOULD lookup the name in `$XDG_CONFIG_DIRS/oci-discovery/ref-engine-discovery.json`, as defined in the [XDG Base Directory Specification 0.8][XDG].
+When `oci-discovery/ref-engine-discovery.json` is located under multiple base directories, consumers SHOULD merge the configurations.
+
+When merging multiple [`application/vnd.oci.regexp-ref-engines.v1+json` objects](#regexp-ref-engines-objects), the result MUST be another `application/vnd.oci.regexp-ref-engines.v1+json` object.
+For each root key in any source configuration, the merged configuration MUST have a root entry for that key, the value of which MUST match the value for that key from the most-preferred source configuration with an entry for that key.
+
+### Example
+
+```
+$ cat ~/.config/oci-discovery/ref-engine-discovery.json
+{
+  "^[^/]*example\.com/.*$": {
+    "refEngines": [
+      {
+        "protocol": "oci-index-template-v1",
+        "uri": "https://{host}/ref/{name}"
+      }
+    ]
+  },
+  "^a\.example\.com/app#.*$": {
+    "refEngines": [
+      {
+        "protocol": "oci-index-template-v1",
+        "uri": "https://{host}/oci-ref/{name}"
+      }
+    ],
+    "casEngines": [
+      {
+        "protocol": "oci-cas-template-v1",
+        "uri": "https://a.example.com/cas/{algorithm}/{encoded:2}/{encoded}"
+      }
+    ]
+  }
+}
+```
+
+The [`oci-index-template-v1` protocol](index-template.md) is [registered](ref-engine-protocols.md).
+The [`oci-cas-template-v1` protocol](cas-template.md) is [registered](cas-engine-protocols.md).
+
+With this configuration, an image named `a.example.com/app#1.0` will match both entries.
+A `^a\.example\.com/app#.*$` is longer (24 characters to `^[^/]*example\.com/.*$`'s 22), so it is the preferred match.
+A client would check the `oci-index-template-v1` ref engine at `https://{host}/ref/{name}` first, and then fall back to the `oci-index-template-v1` ref engine at `https://{host}/oci-ref/{name}` if further [Merkle roots](glossary.md#merkle-root) were needed.
+
+[ERE]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04
+[media-type]: https://tools.ietf.org/html/rfc6838
+[POSIX-LC_COLLATE]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html#tag_07_03_02_06
+[rfc7159-s4]: https://tools.ietf.org/html/rfc7159#section-4
+[rfc7159-s5]: https://tools.ietf.org/html/rfc7159#section-5
+[XDG]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.8.html


### PR DESCRIPTION
This allows tools (like `oci-discovery`) to use local files to provide ref- and CAS-engine suggestions for arbitrary image names.  Besides the general flexibility, this demonstrates the flexibility of the discovery approach and underscores the fact that the well-known URI approach is just one of many possible approaches.

The commits running up to the tip are smaller pivots to setup for the new protocol.  I can spin them out into their own PRs if you like, or break any of the commits up into even smaller pivots if that will help.  If/when we land the Markdown spec for the XDG protocol, I'll file a separate PR updating the Python package.