### PR TITLE
oci_discovery/uri_template/test: Test URITemplate.__str__

### DIFF
--- a/oci_discovery/uri_template/test.py
+++ b/oci_discovery/uri_template/test.py
@@ -172,6 +172,7 @@ class TestURITemplate(unittest.TestCase):
                             self.fail(
                                 msg="entries in both 'exceptions' and 'wrong_values'.  Pick one.")
                         obj = cls(uri=template)
+                        self.assertEqual(str(obj), template)
                         try:
                             expanded = obj.expand(**variables)
                         except Exception as error:


### PR DESCRIPTION
This gives us complete coverage for the `uri_template` package, as measured by:

```
$ pip install --user coverage
$ python -m coverage run -m unittest discover
$ python -m coverage report | grep uri_template
oci_discovery/uri_template/__init__.py        10      0   100%
oci_discovery/uri_template/test.py            33      5    85%
```

Incomplete coverage in `test.py` is acceptable; the unexercised statements are due to:

* The presence of `uritemplate` on my local system, so I don't excercise the `ImportError` fallback.  The fallback allows the tests to run on systems without `uritemplate`, so we want to keep it.

* The lack of buggy double entries, so I don't exercise the “entries in both” failure.  This guard protects devs from adding buggy double entries, so we want to keep it.

* The absence of any unexpected failures, so I don't exercise the `raise`.  We want to keep it to get good messages if/when an implementation does a worse job of implementing the RFC.

* The presence of all expected failures, so I don't exercise the “no longer raises an exception” failure.  We want to keep it to get good messages if/when an implementation does a better job of implementing the RFC.