### PR TITLE
oci_discovery/fetch_json/test: Fix undefined expected

### DIFF
--- a/oci_discovery/fetch_json/test.py
+++ b/oci_discovery/fetch_json/test.py
@@ -163,4 +163,4 @@ class TestFetchJSON(unittest.TestCase):
                 target='oci_discovery.fetch_json._urllib_request.urlopen',
                 return_value=response):
             fetched = fetch(uri=initial_uri)
-        self.assertEqual(fetched, {'uri': final_uri, 'json': expected})
+        self.assertEqual(fetched, {'uri': final_uri, 'json': {}})


### PR DESCRIPTION
In `test_redirect`, avoiding:

```
$ make test-python
…
Traceback (most recent call last):
  File "/.../oci_discovery/fetch_json/test.py", line 166, in test_redirect
    self.assertEqual(fetched, {'uri': final_uri, 'json': expected})
NameError: name 'expected' is not defined
…
```

Fixing a copy/paste error from #55.