### PR TITLE
oci_discovery/ref_engine_discovery/test_xdg: Complete xdg coverage

### DIFF
--- a/oci_discovery/ref_engine_discovery/test_xdg.py
+++ b/oci_discovery/ref_engine_discovery/test_xdg.py
@@ -131,9 +131,9 @@ class TestEngine(unittest.TestCase):
 
     def test_load_config_good(self):
         def path_generator(path=None):
-            for filename in ['short', 'long']:
+            for filename in ['short', 'missing-file', 'long']:
                 yield os.path.join(xdg.ROOT, filename)
-        short, long = list(path_generator())
+        short, _, long = list(path_generator())
         with unittest.mock.patch(
                 target='oci_discovery.ref_engine_discovery.xdg.config_paths',
                 new=path_generator):

--- a/oci_discovery/ref_engine_discovery/test_xdg.py
+++ b/oci_discovery/ref_engine_discovery/test_xdg.py
@@ -102,6 +102,8 @@ class TestEngine(unittest.TestCase):
             return io.StringIO('[]')
         if filename == 'invalid-regexp':
             return io.StringIO('{"[": "invalid-regexp"}')
+        if filename == 'non-dict-value':
+            return io.StringIO(r'{"^example\\.com/.*$": "non-dict"}')
         if filename == 'good':
             return io.StringIO(r"""{
               "^[^/]*example\\.com/.*$": {
@@ -198,7 +200,7 @@ class TestEngine(unittest.TestCase):
                 )
                 self.assertRegex(logs.output[0], regex)
 
-    def test_ref_engines(self):
+    def test_ref_engines_good(self):
         def path_generator(path=None):
             yield os.path.join(xdg.ROOT, 'good')
         good = next(path_generator())
@@ -257,3 +259,21 @@ class TestEngine(unittest.TestCase):
                 references = list(engine.ref_engines(name=name))
                 self.assertEqual(
                     [ref.dict() for ref in references], expected)
+
+    def test_ref_engines_bad(self):
+        def path_generator(path=None):
+            yield os.path.join(xdg.ROOT, 'non-dict-value')
+        with unittest.mock.patch(
+                target='oci_discovery.ref_engine_discovery.xdg.config_paths',
+                new=path_generator):
+            with unittest.mock.patch(
+                    target='oci_discovery.ref_engine_discovery.xdg.open',
+                    new=self._mock_open,
+                    create=True):  # create=True not needed for Python 3.5+
+                engine = xdg.Engine()
+                with self.assertLogs(xdg._LOGGER, level=logging.WARNING) as logs:
+                    references = list(engine.ref_engines(
+                        name='example.com/app#1.0'))
+        self.assertRegex(
+            logs.output[0],
+            '^WARNING:oci_discovery\.ref_engine_discovery\.xdg:file:///non-dict-value claimed to return application/vnd\.oci\.ref-engines\.v1\+json but actually returned non-dict$')


### PR DESCRIPTION
Adding tests for the `yield_from_ref_engines_object` `ValueError` handling and the `FileNotFoundError` handling.