### PR TITLE
well-known-uri-ref-engine-discovery: Drop 'auth*' params from the Docker example

### DIFF
--- a/well-known-uri-ref-engine-discovery.md
+++ b/well-known-uri-ref-engine-discovery.md
@@ -50,9 +50,7 @@ $ curl -H 'Accept: application/vnd.oci.ref-engines.v1+json' https://a.b.example.
     },
     {
       "protocol": "docker",
-      "uri": "https://index.docker.io/v2",
-      "authUri": "https://auth.docker.io/token",
-      "authService": "registry.docker.io",
+      "uri": "https://index.docker.io/v2"
     }
   ]
 }


### PR DESCRIPTION
Docker registries [should include both of these][1] in their `WWW-Authenticate` response, and Docker's registry does:

```console
$ curl -I -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' https://index.docker.io/v2/library/docker/manifests/1.12.1
HTTP/1.1 401 Unauthorized
Content-Type: application/json; charset=utf-8
Docker-Distribution-Api-Version: registry/2.0
Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/docker:pull"
Date: Fri, 26 Jan 2018 04:58:02 GMT
Content-Length: 157
Strict-Transport-Security: max-age=31536000
```

The `WWW-Authenticate` header is [specified in RFC 7235][2], and the `Bearer` token is [specified in RFC 6750][3].  RFC 7235 defines `realm` and [allows for per-scheme extensions][4]:

> The realm value is a string, generally assigned by the origin server, that can have additional semantics specific to the authentication scheme.

But RFC 6750 has nothing to say about its semantics, so interpreting it as the auth-server URI seems to be a Dockerism.  Similarly, the `service` parameter seems to be a Dockerism, with no mentions of `service` in RFC 6750.  `scope` is [covered in RFC 6750][5], which delegates the definition to [RFC 6749][6].

RFC 6749 covers [supplying the `scope` to the auth-server as a query parameter][7].  It also covers `client_id`, which Docker [also mentions][8].  RFC 6749 [requires auth-requests to include `response_type=code`][7], which Docker [does not mention][8]; but Docker accepts the RFC value:

```console
$ curl -s 'https://auth.docker.io/token?response_type=code&client_id=testing&service=registry.docker.io&scope=repository:library/docker:pull' | jq -S .
{
  "access_token": "…",
  "expires_in": 300,
  "issued_at": "2018-01-26T05:35:56.860615325Z",
  "token": "…"
}
```

Docker does not seem to implement [RFC 6749's recommended `state` parameter][7].

With both “use `realm` as the auth server” and “pass through `service` as an auth query parameter” as Dockerisms, the RFCs are not sufficient in themselves to specify Docker's current auth protocol.  These are not vanilla bearer tokens.  But the information we previously supplied via `authUri` and `authService` *is* in the intial resource response, so we can stop supplying those ourselves.

[1]: https://github.com/docker/distribution/blob/v2.6.2/docs/spec/auth/token.md#how-to-authenticate
[2]: https://tools.ietf.org/html/rfc7235#section-4.1
[3]: https://tools.ietf.org/html/rfc6750
[4]: https://tools.ietf.org/html/rfc7235#section-2.2
[5]: https://tools.ietf.org/html/rfc6750#section-3
[6]: https://tools.ietf.org/html/rfc6749#section-3.3
[7]: https://tools.ietf.org/html/rfc6749#section-4.1.1
[8]: https://github.com/docker/distribution/blob/v2.6.2/docs/spec/auth/token.md#requesting-a-token